### PR TITLE
Add `iw` to RTL lang list

### DIFF
--- a/__test__/lib/rtl-detect-private.spec.js
+++ b/__test__/lib/rtl-detect-private.spec.js
@@ -139,6 +139,7 @@ describe('rtl-detect', function () {
                 'fa',
                 'glk',
                 'he',
+                'iw',
                 'ku',
                 'mzn',
                 'nqo',

--- a/lib/rtl-detect.js
+++ b/lib/rtl-detect.js
@@ -158,6 +158,7 @@ Object.defineProperty(self, '_BIDI_RTL_LANGS', {
         'fa',   /* 'فارسی', Persian */
         'glk',  /* 'گیلکی', Gilaki */
         'he',   /* 'עברית', Hebrew */
+        'iw',   /* 'עברית', Hebrew (old ISO code) */
         'ku',   /* 'Kurdî / كوردی', Kurdish */
         'mzn',  /* 'مازِرونی', Mazanderani */
         'nqo',  /* N'Ko */
@@ -165,7 +166,7 @@ Object.defineProperty(self, '_BIDI_RTL_LANGS', {
         'ps',   /* 'پښتو', Pashto, */
         'sd',   /* 'سنڌي', Sindhi */
         'ug',   /* 'Uyghurche / ئۇيغۇرچە', Uyghur */
-        'ur',    /* 'اردو', Urdu */
+        'ur',   /* 'اردو', Urdu */
         'yi'    /* 'ייִדיש', Yiddish */
     ],
     writable: false,


### PR DESCRIPTION
Hebrew's lang code is now `he`, but previously it was `iw` and old versions of Java still use it.

Adding `iw` to the RTL list allows apps using old versions of node to use this addon and get the correct RTL value for `iw`, which does not work today.